### PR TITLE
Refactor : MainNavigation 라우팅 명칭변경

### DIFF
--- a/src/components/Report/ReportSummary.tsx
+++ b/src/components/Report/ReportSummary.tsx
@@ -23,9 +23,8 @@ const Title = styled.Text`
   font-weight: bold;
 `;
 
-const Description = styled.Text`
+const Description = styled.View`
   margin-top: 8px;
-  color: #555;
 `;
 
 const DetailButton = styled(TouchableOpacity)`
@@ -41,22 +40,63 @@ const ButtonText = styled.Text`
   font-size: 14px;
 `;
 
-const ReportSummary = ({navigation}) => {
+const CheckItem = styled.View`
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: 4px;
+`;
+
+const CheckText = styled.Text`
+  margin-left: 8px;
+  color: #555;
+`;
+
+const ReportSummary = ({report, navigation}) => {
   const handleDetailPress = () => {
-    navigation.navigate('ReportDetail'); // 간병 보고서 상세 페이지로 이동
+    navigation.navigate('ReportDetail', {report}); // 상세 페이지로 데이터 전달
   };
 
   return (
     <Container>
       <Row>
-        <Title>2024년 10월 16일</Title>
+        <Title>{report.date}</Title>
         <TouchableOpacity>
           <Pen width={20} height={20} />
         </TouchableOpacity>
       </Row>
       <Row>
         <Book width={50} height={50} />
-        <Description>배변활동, 식사여부 등 간병 보고서 간략 정보</Description>
+        <Description>
+          <CheckItem>
+            <CheckText>
+              배변활동:{' '}
+              {Object.keys(report.activities.bowel)
+                .filter(key => report.activities.bowel[key])
+                .join(', ') || '없음'}
+            </CheckText>
+          </CheckItem>
+          <CheckItem>
+            <CheckText>
+              식사여부:{' '}
+              {Object.keys(report.activities.meal)
+                .filter(key => report.activities.meal[key])
+                .join(', ') || '없음'}
+            </CheckText>
+          </CheckItem>
+          <CheckItem>
+            <CheckText>
+              투약:{' '}
+              {Object.keys(report.medications)
+                .filter(key =>
+                  Object.values(report.medications[key]).some(value => value),
+                )
+                .join(', ') || '없음'}
+            </CheckText>
+          </CheckItem>
+          <CheckItem>
+            <CheckText>특이사항: {report.notes || '없음'}</CheckText>
+          </CheckItem>
+        </Description>
       </Row>
       <DetailButton onPress={handleDetailPress}>
         <ButtonText>자세히 보기</ButtonText>

--- a/src/components/common/BottomTabNavigator.tsx
+++ b/src/components/common/BottomTabNavigator.tsx
@@ -2,10 +2,10 @@
 import React from 'react';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {Text} from 'react-native';
-import HomeScreen from '../../pages/Home/Home';
-import ReportScreen from '../../pages/Report/Report';
-import GalleryScreen from '../../pages/Gallery/Gallery';
-import MessageScreen from '../../pages/Message/Message';
+import Home from '../../pages/Home/Home';
+import Report from '../../pages/Report/Report';
+import Gallery from '../../pages/Gallery/Gallery';
+import Message from '../../pages/Message/Message';
 import TopNavigationBar from './TopNavigationBar';
 
 // SVG 아이콘 컴포넌트
@@ -23,9 +23,9 @@ const BottomTabNavigator = () => {
         tabBarIcon: ({focused}) => {
           let IconComponent;
           if (route.name === 'Home') IconComponent = HomeIcon;
-          else if (route.name === 'Reports') IconComponent = ReportIcon;
+          else if (route.name === 'Report') IconComponent = ReportIcon;
           else if (route.name === 'Gallery') IconComponent = GalleryIcon;
-          else if (route.name === 'Messages') IconComponent = MessageIcon;
+          else if (route.name === 'Message') IconComponent = MessageIcon;
 
           return IconComponent ? (
             <IconComponent width={24} height={24} />
@@ -34,9 +34,9 @@ const BottomTabNavigator = () => {
         tabBarLabel: ({focused}) => {
           let label;
           if (route.name === 'Home') label = '홈';
-          else if (route.name === 'Reports') label = '간병 보고서';
+          else if (route.name === 'Report') label = '간병 보고서';
           else if (route.name === 'Gallery') label = '갤러리';
-          else if (route.name === 'Messages') label = '쪽지';
+          else if (route.name === 'Message') label = '쪽지';
 
           return (
             <Text style={{color: focused ? '#000' : '#888'}}>{label}</Text>
@@ -49,17 +49,17 @@ const BottomTabNavigator = () => {
         },
         header: () => {
           let title = '';
-          if (route.name === 'Reports') title = '간병 보고서';
+          if (route.name === 'Report') title = '간병 보고서';
           else if (route.name === 'Gallery') title = '갤러리';
-          else if (route.name === 'Messages') title = '쪽지';
+          else if (route.name === 'Message') title = '쪽지';
 
           return <TopNavigationBar title={title} />;
         },
       })}>
-      <Tab.Screen name="Home" component={HomeScreen} />
-      <Tab.Screen name="Reports" component={ReportScreen} />
-      <Tab.Screen name="Gallery" component={GalleryScreen} />
-      <Tab.Screen name="Messages" component={MessageScreen} />
+      <Tab.Screen name="Home" component={Home} />
+      <Tab.Screen name="Report" component={Report} />
+      <Tab.Screen name="Gallery" component={Gallery} />
+      <Tab.Screen name="Message" component={Message} />
     </Tab.Navigator>
   );
 };

--- a/src/components/common/TopNavigationBar.tsx
+++ b/src/components/common/TopNavigationBar.tsx
@@ -23,10 +23,22 @@ function TopNavigationBar({title}: TopNavigationProps) {
       </LeftSection>
       <CenterSection>{title ? <Title>{title}</Title> : null}</CenterSection>
       <RightSection>
-        <TouchableOpacity onPress={() => navigation.navigate('Landing')/**알림 페이지를 구성하기 전 임시 네비게이트*/}>
+        <TouchableOpacity
+          onPress={
+            () =>
+              navigation.navigate(
+                'Landing',
+              ) /**알림 페이지를 구성하기 전 임시 네비게이트*/
+          }>
           <BellIcon width={30} height={30} />
         </TouchableOpacity>
-        <TouchableOpacity onPress={() => navigation.navigate('Landing')/**마이 페이지를 구성하기 전 임시 네비게이트*/}>
+        <TouchableOpacity
+          onPress={
+            () =>
+              navigation.navigate(
+                'Landing',
+              ) /**마이 페이지를 구성하기 전 임시 네비게이트*/
+          }>
           <ProfileIcon width={30} height={30} />
         </TouchableOpacity>
       </RightSection>

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -3,15 +3,15 @@ import {createStackNavigator} from '@react-navigation/stack';
 import BottomTabNavigator from '../components/common/BottomTabNavigator';
 import Landing from '../pages/Landing/Landing';
 import UserCategory from '../pages/UserCategory/UserCategory';
-import HomeScreen from '../pages/Home/Home';
-import GalleryScreen from '../pages/Gallery/Gallery';
-import ReportScreen from '../pages/Report/Report';
-import MessageScreen from '../pages/Message/Message';
-import ReportCreate from '../pages/Report/ReportCreate';
+import Home from '../pages/Home/Home';
+import Gallery from '../pages/Gallery/Gallery';
+import Report from '../pages/Report/Report';
+import Message from '../pages/Message/Message';
 import ProtectorInfo from '../pages/Info/ProtectorInfo';
 import CaregiverInfo from '../pages/Info/CaregiverInfo';
 import AcquaintanceInfo from '../pages/Info/AcquaintanceInfo';
-
+import ReportDetail from '../pages/Report/ReportDetail';
+import ReportCreate from '../pages/Report/ReportCreate';
 const Stack = createStackNavigator();
 
 const MainNavigator = () => {
@@ -22,11 +22,12 @@ const MainNavigator = () => {
       <Stack.Screen name="Landing" component={Landing} />
       <Stack.Screen name="UserCategory" component={UserCategory} />
       <Stack.Screen name="Main" component={BottomTabNavigator} />
-      <Stack.Screen name="Home" component={HomeScreen} />
-      <Stack.Screen name="Gallery" component={GalleryScreen} />
-      <Stack.Screen name="Reports" component={ReportScreen} />
-      <Stack.Screen name="Messages" component={MessageScreen} />
+      <Stack.Screen name="Home" component={Home} />
+      <Stack.Screen name="Gallery" component={Gallery} />
+      <Stack.Screen name="Report" component={Report} />
+      <Stack.Screen name="Message" component={Message} />
       <Stack.Screen name="ReportCreate" component={ReportCreate} />
+      <Stack.Screen name="ReportDetail" component={ReportDetail} />
       <Stack.Screen name="ProtectorInfo" component={ProtectorInfo} />
       <Stack.Screen name="CaregiverInfo" component={CaregiverInfo} />
       <Stack.Screen name="AcquaintanceInfo" component={AcquaintanceInfo} />

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -262,7 +262,7 @@ const Home = () => {
             </IconContainer>
             <SectionTitle>최근 간병 보고서</SectionTitle>
           </SectionTitleContainer>
-          <MoreButton onPress={() => navigation.navigate('Reports')}>
+          <MoreButton onPress={() => navigation.navigate('Report')}>
             <MoreText>더보기 &gt;</MoreText>
           </MoreButton>
         </SectionHeader>
@@ -288,7 +288,7 @@ const Home = () => {
             </IconContainer>
             <SectionTitle>최근 쪽지</SectionTitle>
           </SectionTitleContainer>
-          <MoreButton onPress={() => navigation.navigate('Messages')}>
+          <MoreButton onPress={() => navigation.navigate('Message')}>
             <MoreText>더보기 &gt;</MoreText>
           </MoreButton>
         </SectionHeader>

--- a/src/pages/Report/Report.tsx
+++ b/src/pages/Report/Report.tsx
@@ -1,8 +1,8 @@
 import React, {useState} from 'react';
 import styled from 'styled-components/native';
-import {ScrollView} from 'react-native';
-import ReportSummary from '../../components/Report/ReportSummary'; // 요약 컴포넌트
-import FloatingButton from '../../components/Report/FloatingButton'; // + 버튼
+import {ScrollView, Text, View} from 'react-native';
+import ReportSummary from '../../components/Report/ReportSummary';
+import FloatingButton from '../../components/Report/FloatingButton';
 
 const Container = styled.View`
   flex: 1;
@@ -25,6 +25,17 @@ const ReportList = styled(ScrollView)`
   padding: 16px;
 `;
 
+const EmptyMessageContainer = styled.View`
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+`;
+
+const EmptyMessageText = styled.Text`
+  font-size: 16px;
+  color: #888;
+`;
+
 const Report = ({navigation}) => {
   const [reports, setReports] = useState([]); // 보고서 리스트 상태
 
@@ -38,15 +49,21 @@ const Report = ({navigation}) => {
 
   return (
     <Container>
-      <ReportList>
-        {reports.map((report, index) => (
-          <ReportSummary
-            key={index}
-            report={report}
-            onDetailPress={() => handleDetail(report)}
-          />
-        ))}
-      </ReportList>
+      {reports.length > 0 ? (
+        <ReportList>
+          {reports.map((report, index) => (
+            <ReportSummary
+              key={index}
+              report={report}
+              onDetailPress={() => handleDetail(report)}
+            />
+          ))}
+        </ReportList>
+      ) : (
+        <EmptyMessageContainer>
+          <EmptyMessageText>아직 작성된 간병보고서가 없어요!</EmptyMessageText>
+        </EmptyMessageContainer>
+      )}
       {/* 오른쪽 하단 + 버튼 */}
       <FloatingButton
         onPress={() => navigation.navigate('ReportCreate', {handleAddReport})}

--- a/src/pages/Report/ReportDetail.tsx
+++ b/src/pages/Report/ReportDetail.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import {ScrollView, Text, View} from 'react-native';
+import styled from 'styled-components/native';
+
+const Container = styled.ScrollView`
+  flex: 1;
+  background-color: #ffffff;
+  padding: 16px;
+`;
+
+const Header = styled.View`
+  padding: 16px;
+  align-items: center;
+  border-bottom-width: 1px;
+  border-bottom-color: #ddd;
+`;
+
+const HeaderText = styled.Text`
+  font-size: 18px;
+  font-weight: bold;
+`;
+
+const Section = styled.View`
+  margin: 16px 0;
+`;
+
+const SectionTitle = styled.Text`
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 8px;
+`;
+
+const DetailText = styled.Text`
+  color: #555;
+`;
+
+const ReportDetail = ({route}) => {
+  const {report} = route.params;
+
+  return (
+    <Container>
+      <Header>
+        <HeaderText>{report.date} 보고서</HeaderText>
+      </Header>
+      <Section>
+        <SectionTitle>배변활동</SectionTitle>
+        <DetailText>
+          {Object.keys(report.activities.bowel)
+            .map(key => `${key}: ${report.activities.bowel[key] ? 'O' : 'X'}`)
+            .join(', ')}
+        </DetailText>
+      </Section>
+      <Section>
+        <SectionTitle>식사여부</SectionTitle>
+        <DetailText>
+          {Object.keys(report.activities.meal)
+            .map(key => `${key}: ${report.activities.meal[key] ? 'O' : 'X'}`)
+            .join(', ')}
+        </DetailText>
+      </Section>
+      <Section>
+        <SectionTitle>투약 정보</SectionTitle>
+        {Object.entries(report.medications).map(([key, value]) => (
+          <DetailText key={key}>
+            {key}:{' '}
+            {Object.keys(value)
+              .map(time => `${time}: ${value[time] ? 'O' : 'X'}`)
+              .join(', ')}
+          </DetailText>
+        ))}
+      </Section>
+      <Section>
+        <SectionTitle>특이사항</SectionTitle>
+        <DetailText>{report.notes || '없음'}</DetailText>
+      </Section>
+    </Container>
+  );
+};
+
+export default ReportDetail;


### PR DESCRIPTION
- HomeScreen -> Home 등 으로 해당 컴포넌트 이름으로 명칭 통일하였습니다. Messages->Message, Reports->Report 등 변경하였습니다.
    <Stack.Navigator
      initialRouteName="Landing"
      screenOptions={{headerShown: false}}>
      <Stack.Screen name="Landing" component={Landing} />
      <Stack.Screen name="UserCategory" component={UserCategory} />
      <Stack.Screen name="Main" component={BottomTabNavigator} />
      <Stack.Screen name="Home" component={Home} />
      <Stack.Screen name="Gallery" component={Gallery} />
      <Stack.Screen name="Report" component={Report} />
      <Stack.Screen name="Message" component={Message} />
      <Stack.Screen name="ReportCreate" component={ReportCreate} />
      <Stack.Screen name="ReportDetail" component={ReportDetail} />
      <Stack.Screen name="ProtectorInfo" component={ProtectorInfo} />
      <Stack.Screen name="CaregiverInfo" component={CaregiverInfo} />
      <Stack.Screen name="AcquaintanceInfo" component={AcquaintanceInfo} />
    </Stack.Navigator>
  );
};


