### PR TITLE
[feat] 폰트 크기 설정 슬라이더 기능 구현 및 스타일링 수정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import {SafeAreaProvider} from 'react-native-safe-area-context';
 import {ReportProvider} from './src/store/ReportContext'; // Context 추가
 import {MessageProvider} from './src/store/MessageContext';
 import {UserProvider} from './src/store/UserContext';
+import { FontSizeProvider } from './src/store/FontSizeContext';
 
 const AppContainer = styled.SafeAreaView`
   flex: 1;
@@ -22,15 +23,17 @@ const App = () => {
   return (
     <SafeAreaProvider>
       <AppContainer>
-        <UserProvider>
-          <ReportProvider>
-            <MessageProvider>
-              <NavigationContainer>
-                <MainNavigator />
-              </NavigationContainer>
-            </MessageProvider>
-          </ReportProvider>
-        </UserProvider>
+        <FontSizeProvider>
+          <UserProvider>
+            <ReportProvider>
+              <MessageProvider>
+                <NavigationContainer>
+                  <MainNavigator />
+                </NavigationContainer>
+              </MessageProvider>
+            </ReportProvider>
+          </UserProvider>
+        </FontSizeProvider>
       </AppContainer>
     </SafeAreaProvider>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-native-async-storage/async-storage": "^2.1.0",
         "@react-native-clipboard/clipboard": "^1.15.0",
         "@react-native-community/datetimepicker": "^8.2.0",
+        "@react-native-community/slider": "^4.5.5",
         "@react-native-picker/picker": "^2.9.0",
         "@react-native-seoul/kakao-login": "^5.4.1",
         "@react-navigation/bottom-tabs": "^6.0.0",
@@ -3270,6 +3271,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@react-native-community/slider": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.5.tgz",
+      "integrity": "sha512-x2N415pg4ZxIltArOKczPwn7JEYh+1OxQ4+hTnafomnMsqs65HZuEWcX+Ch8c5r8V83DiunuQUf5hWGWlw8hQQ==",
+      "license": "MIT"
     },
     "node_modules/@react-native-picker/picker": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@react-native-async-storage/async-storage": "^2.1.0",
     "@react-native-clipboard/clipboard": "^1.15.0",
     "@react-native-community/datetimepicker": "^8.2.0",
+    "@react-native-community/slider": "^4.5.5",
     "@react-native-picker/picker": "^2.9.0",
     "@react-native-seoul/kakao-login": "^5.4.1",
     "@react-navigation/bottom-tabs": "^6.0.0",

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -17,6 +17,7 @@ import Callback from '../pages/Auth/Callback';
 import ProtectorMypage from '../pages/Mypage/ProtectorMyPage';
 import CaregiverMypage from '../pages/Mypage/CaregiverMypage';
 import AcquaintanceMypage from '../pages/Mypage/AcquaintanceMypage';
+import FontSizeChange from '../pages/Mypage/FontSizeChange';
 import ViewProtectorProfile from '../pages/ProtectorDo/ViewProtectorProfile';
 import EditProtectorProfile from '../pages/ProtectorDo/EditProtectorProfile';
 import ViewCaregiverProfile from '../pages/ProtectorDo/ViewCaregiverProfile';
@@ -55,6 +56,7 @@ export type RootStackParamList = {
   ProtectorMypage: undefined;
   CaregiverMypage: undefined;
   AcquaintanceMypage: undefined;
+  FontSizeChange: undefined;
 };
 
 // Stack Navigator 생성
@@ -91,6 +93,7 @@ const MainNavigator = () => {
       <Stack.Screen name="ProtectorMypage" component={ProtectorMypage} />
       <Stack.Screen name="CaregiverMypage" component={CaregiverMypage} />
       <Stack.Screen name="AcquaintanceMypage" component={AcquaintanceMypage} />
+      <Stack.Screen name="FontSizeChange" component={FontSizeChange} />
     </Stack.Navigator>
   );
 };

--- a/src/pages/Mypage/FontSizeChange.tsx
+++ b/src/pages/Mypage/FontSizeChange.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Slider from '@react-native-community/slider';
+import { useFontSize } from '../../store/FontSizeContext';
+
+const FontSizeChange = () => {
+  const { setScale } = useFontSize();
+  const [sliderValue, setSliderValue] = useState<number>(1); // 초기값 설정 (1 = 기본)
+
+  const handleFontSizeChange = (value: number) => {
+    const scales = [1, 1.25, 1.5]; // 기본, 크게, 많이 크게
+    setSliderValue(value);
+    setScale(scales[Math.round(value)]);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>폰트 크기 설정</Text>
+      <Slider
+        style={styles.slider}
+        minimumValue={0}
+        maximumValue={2}
+        step={1}
+        value={sliderValue} // 초기값 설정
+        onValueChange={(value) => handleFontSizeChange(value)} // 값 변경 핸들러
+      />
+      <Text style={styles.label}>
+        {sliderValue === 0
+          ? '기본'
+          : sliderValue === 1
+          ? '크게'
+          : '많이 크게'}
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 18,
+    marginBottom: 20,
+  },
+  slider: {
+    width: '80%',
+    height: 40,
+  },
+  label: {
+    marginTop: 10,
+    fontSize: 16,
+  },
+});
+
+export default FontSizeChange;

--- a/src/pages/Mypage/ProtectorMyPage.tsx
+++ b/src/pages/Mypage/ProtectorMyPage.tsx
@@ -1,16 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components/native';
-import {Clipboard, TouchableOpacity} from 'react-native';
+import { Clipboard, TouchableOpacity } from 'react-native';
 import TopNavigationBar from '../../components/common/TopNavigationBar';
-import {useUser} from '../../store/UserContext';
-import {useNavigation} from '@react-navigation/native';
-import {NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {RootStackParamList} from '../../navigation/MainNavigator';
+import { useUser } from '../../store/UserContext';
+import { useFontSize } from '../../store/FontSizeContext'; // FontSizeContext 추가
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../navigation/MainNavigator';
 import ApiService from '../../utils/api';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
-//상단에 미니 프로필을 위한 api 연결
 interface ApiResponse {
   status: string;
   message: string;
@@ -28,6 +28,10 @@ interface ApiResponse {
       medicationInfos: any[];
     };
   };
+}
+
+interface FontSizeProps {
+  fontSizes: number[];
 }
 
 const Container = styled.View`
@@ -59,15 +63,15 @@ const ProfileInfo = styled.View`
   flex: 1;
 `;
 
-const ProfileName = styled.Text`
-  font-size: 18px;
+const ProfileName = styled.Text<FontSizeProps>`
+  font-size: ${({ fontSizes }) => fontSizes[3]}px; /* 기본 18px */
   font-weight: bold;
   margin-bottom: 5px;
 `;
 
-const ProfileContact = styled.Text`
+const ProfileContact = styled.Text<FontSizeProps>`
   color: #666;
-  font-size: 14px;
+  font-size: ${({ fontSizes }) => fontSizes[1]}px; /* 기본 14px */
 `;
 
 const MenuSection = styled.View`
@@ -76,18 +80,19 @@ const MenuSection = styled.View`
   padding: 15px 0;
 `;
 
-const MenuTitle = styled.Text`
-  font-size: 16px;
+const MenuTitle = styled.Text<FontSizeProps>`
+  font-size: ${({ fontSizes }) => fontSizes[2]}px; /* 기본 16px */
   font-weight: bold;
   padding: 0 20px 10px 20px;
 `;
 
-const MenuItem = styled.TouchableOpacity`
+const MenuItemContainer = styled.TouchableOpacity`
   padding: 15px 20px;
+  background-color: #fff;
 `;
 
-const MenuText = styled.Text`
-  font-size: 16px;
+const MenuText = styled.Text<FontSizeProps>`
+  font-size: ${({ fontSizes }) => fontSizes[2]}px; /* 기본 16px */
   color: #333;
 `;
 
@@ -99,15 +104,15 @@ const CodeSection = styled.View`
   margin: 16px;
 `;
 
-const CodeTitle = styled.Text`
-  font-size: 18px;
+const CodeTitle = styled.Text<FontSizeProps>`
+  font-size: ${({ fontSizes }) => fontSizes[3]}px; /* 기본 18px */
   font-weight: bold;
   margin-bottom: 15px;
   color: #333;
 `;
 
-const CodeText = styled.Text`
-  font-size: 24px;
+const CodeText = styled.Text<FontSizeProps>`
+  font-size: ${({ fontSizes }) => fontSizes[5]}px; /* 기본 24px */
   font-weight: bold;
   color: #00d6a3;
   margin-bottom: 15px;
@@ -122,25 +127,24 @@ const CopyButton = styled.TouchableOpacity`
   align-items: center;
 `;
 
-const CopyButtonText = styled.Text`
+const CopyButtonText = styled.Text<FontSizeProps>`
   color: #ffffff;
-  font-size: 16px;
+  font-size: ${({ fontSizes }) => fontSizes[2]}px; /* 기본 16px */
 `;
-
 
 const ProtectorMypage = () => {
   const navigation = useNavigation<NavigationProp>();
-  const {protectorData} = useUser();//유저컨텍스트
+  const { protectorData } = useUser(); // 유저컨텍스트
+  const { fontSizes } = useFontSize(); // 폰트 크기 가져오기
+  const [profileData, setProfileData] = useState<ApiResponse['data'] | null>(null);
+
   const copyToClipboard = async (code: string) => {
     try {
       await Clipboard.setString(code);
-      // 복사 완료 알림
     } catch (error) {
       console.error('Failed to copy to clipboard:', error);
     }
   };
-
-  const [profileData, setProfileData] = useState<ApiResponse['data'] | null>(null);
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -154,7 +158,6 @@ const ProtectorMypage = () => {
     fetchProfile();
   }, []);
 
-
   return (
     <Container>
       <TopNavigationBar title="보호자 프로필" />
@@ -162,73 +165,51 @@ const ProtectorMypage = () => {
         <ProfileSection>
           <ProfileImage />
           <ProfileInfo>
-            <ProfileName>
+            <ProfileName fontSizes={fontSizes}>
               {profileData?.guardianInfo?.name || '이름 없음'}
             </ProfileName>
-            <ProfileContact>
-              {profileData ? 
-                `${profileData.patientInfo.name}(${profileData.patientInfo.age})님의 보호자\n${profileData.guardianInfo.phone}` 
+            <ProfileContact fontSizes={fontSizes}>
+              {profileData
+                ? `${profileData.patientInfo.name}(${profileData.patientInfo.age})님의 보호자\n${profileData.guardianInfo.phone}`
                 : '정보 없음'}
             </ProfileContact>
           </ProfileInfo>
         </ProfileSection>
 
         <CodeSection>
-          <CodeTitle>보호자 매칭 코드</CodeTitle>
-          <CodeText>F3Rr102A</CodeText>
+          <CodeTitle fontSizes={fontSizes}>보호자 매칭 코드</CodeTitle>
+          <CodeText fontSizes={fontSizes}>F3Rr102A</CodeText>
           <CopyButton onPress={() => copyToClipboard('F3Rr102A')}>
-            <CopyButtonText>복사하기</CopyButtonText>
+            <CopyButtonText fontSizes={fontSizes}>복사하기</CopyButtonText>
           </CopyButton>
         </CodeSection>
 
         <MenuSection>
-          <MenuTitle>보호자와 환자 관리</MenuTitle>
-          <MenuItem onPress={() => navigation.navigate('ViewProtectorProfile')}>
-            <MenuText>보호자와 환자 프로필 조회</MenuText>
-          </MenuItem>
-          <MenuItem onPress={() => navigation.navigate('EditProtectorProfile')}>
-            <MenuText>보호자와 환자 프로필 수정</MenuText>
-          </MenuItem>
+          <MenuTitle fontSizes={fontSizes}>보호자와 환자 관리</MenuTitle>
+          <MenuItemContainer onPress={() => navigation.navigate('ViewProtectorProfile')}>
+            <MenuText fontSizes={fontSizes}>보호자와 환자 프로필 조회</MenuText>
+          </MenuItemContainer>
+          <MenuItemContainer onPress={() => navigation.navigate('EditProtectorProfile')}>
+            <MenuText fontSizes={fontSizes}>보호자와 환자 프로필 수정</MenuText>
+          </MenuItemContainer>
         </MenuSection>
 
         <MenuSection>
-          <MenuTitle>간병인 관리</MenuTitle>
-          <MenuItem
-            onPress={() =>
-              navigation.navigate('ViewCaregiverProfile')
-            }>
-            <MenuText>간병인 프로필 조회</MenuText>
-          </MenuItem>
-          {/*
-          <MenuItem>
-           기능 구현 질문 없으면 지우고 
-            <MenuText>간병인 평가</MenuText>
-          </MenuItem>
-          */}
+          <MenuTitle fontSizes={fontSizes}>간병인 관리</MenuTitle>
+          <MenuItemContainer onPress={() => navigation.navigate('ViewCaregiverProfile')}>
+            <MenuText fontSizes={fontSizes}>간병인 프로필 조회</MenuText>
+          </MenuItemContainer>
         </MenuSection>
-
-        {/* <MenuSection>
-          <MenuTitle>갤러리</MenuTitle>
-          <MenuItem>
-            <MenuText>사진 전체 다운로드</MenuText>
-          </MenuItem>
-          <MenuItem>
-            <MenuText>최근 삭제한 사진</MenuText>
-          </MenuItem>
-        </MenuSection> */}
 
         <MenuSection>
-          <MenuTitle>설정</MenuTitle>
-          <MenuItem>
-            <MenuText>글씨체</MenuText>
-          </MenuItem>
-          <MenuItem onPress={() => navigation.navigate('DeleteProtectorAccount')}>
-            <MenuText>계정 탈퇴</MenuText>
-          </MenuItem>
+          <MenuTitle fontSizes={fontSizes}>설정</MenuTitle>
+          <MenuItemContainer onPress={() => navigation.navigate('FontSizeChange')}>
+            <MenuText fontSizes={fontSizes}>글씨 크기 변경</MenuText>
+          </MenuItemContainer>
+          <MenuItemContainer onPress={() => navigation.navigate('DeleteProtectorAccount')}>
+            <MenuText fontSizes={fontSizes}>계정 탈퇴</MenuText>
+          </MenuItemContainer>
         </MenuSection>
-
-              
-
       </ScrollContainer>
     </Container>
   );

--- a/src/store/FontSizeContext.js
+++ b/src/store/FontSizeContext.js
@@ -1,0 +1,19 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const FontSizeContext = createContext();
+
+const baseFontSizes = [12, 14, 16, 18, 20, 24];
+
+export const FontSizeProvider = ({ children }) => {
+  const [scale, setScale] = useState(1); // 기본 배율
+
+  const fontSizes = baseFontSizes.map((size) => size * scale);
+
+  return (
+    <FontSizeContext.Provider value={{ fontSizes, setScale }}>
+      {children}
+    </FontSizeContext.Provider>
+  );
+};
+
+export const useFontSize = () => useContext(FontSizeContext);


### PR DESCRIPTION
- 폰트 크기 설정 슬라이더의 초기값 오류 수정
  (슬라이더가 중간값에서 시작하도록 value와 상태 동기화)
- MenuItem 구조 개선: 클릭 영역 및 패딩 문제 해결
- 폰트 크기 Context를 styled-components에 props로 전달
  (fontSizes 사용하여 동적 스타일링 적용)
- ProtectorMypage 내 메뉴 및 슬라이더 UI 개선